### PR TITLE
Activar compresion para PHP y la API

### DIFF
--- a/manifests/web_host.pp
+++ b/manifests/web_host.pp
@@ -46,7 +46,7 @@ define omegaup::web_host(
       ssl_dhparam          => "/etc/ssl/private/${hostname}.dhparam",
       index_files          => $index_files,
       include_files        => $include_files,
-      gzip_types           => 'application/javascript text/html text/css image/x-icon',
+      gzip_types           => 'application/javascript application/json text/html text/css image/x-icon',
       error_pages          => {
         404 => '/404.html',
       },
@@ -79,9 +79,11 @@ define omegaup::web_host(
       client_max_body_size => '100m',
       server_cfg_prepend   => {
         root => $web_root,
+        gzip => 'on'
       },
       try_files            => $try_files,
       require              => File['/etc/nginx/conf.d/default.conf'],
+      gzip_types           => 'application/javascript application/json text/html text/css image/x-icon',
     }
     nginx::resource::server { "${hostname}-ssl":
       ensure            => absent,
@@ -98,7 +100,6 @@ define omegaup::web_host(
       proxy                => undef,
       fastcgi_script       => undef,
       location_cfg_prepend => {
-        gzip               => 'off',
         expires            => '-1',
         fastcgi_param      => 'SCRIPT_FILENAME $document_root$fastcgi_script_name',
         fastcgi_index      => 'index.php',


### PR DESCRIPTION
Por algun motivo esta desactivada compresion para PHP
Y por algun oversight no esta incluido el content type application/json en la lista de tipos a comprimir