### PR TITLE
Actualizar a la version mas reciente de phpunit 5

### DIFF
--- a/manifests/developer_environment.pp
+++ b/manifests/developer_environment.pp
@@ -19,7 +19,7 @@ class omegaup::developer_environment (
     provider => 'pear',
   }
   Anchor['php::begin'] -> class { '::php::phpunit':
-    source      => 'https://phar.phpunit.de/phpunit-5.3.4.phar',
+    source      => 'https://phar.phpunit.de/phpunit-5.phar',
     auto_update => false,
     path        => '/usr/bin/phpunit',
   } -> Anchor['php::end']


### PR DESCRIPTION
Despues de esto, actualizamos las pruebas a que usen la version de TestCase con namespaces y luego podemos subir a la version 6 de phpunit.